### PR TITLE
Add report in-/exclusion test

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,13 @@ TestExclude.prototype.shouldInstrument = function (filename, relFile) {
   return (!this.include || micromatch.any(relFile, this.include, {dotfiles: true})) && !micromatch.any(relFile, this.exclude, {dotfiles: true})
 }
 
+TestExclude.prototype.shouldReport = function (filename, relFile) {
+  relFile = relFile || path.relative(this.cwd, filename)
+
+  relFile = relFile.replace(/^\.[\\/]/, '') // remove leading './' or '.\'.
+  return (!this.include || micromatch.any(relFile, this.include, {dotfiles: true})) && !micromatch.any(relFile, this.exclude, {dotfiles: true})
+}
+
 TestExclude.prototype.pkgConf = function (key, path) {
   const obj = readPkgUp.sync({
     cwd: path || requireMainFilename(require)

--- a/index.js
+++ b/index.js
@@ -64,11 +64,8 @@ TestExclude.prototype.shouldInstrument = function (filename, relFile) {
   return (!this.include || micromatch.any(relFile, this.include, {dotfiles: true})) && !micromatch.any(relFile, this.exclude, {dotfiles: true})
 }
 
-TestExclude.prototype.shouldReport = function (filename, relFile) {
-  relFile = relFile || path.relative(this.cwd, filename)
-
-  relFile = relFile.replace(/^\.[\\/]/, '') // remove leading './' or '.\'.
-  return (!this.include || micromatch.any(relFile, this.include, {dotfiles: true})) && !micromatch.any(relFile, this.exclude, {dotfiles: true})
+TestExclude.prototype.shouldReport = function (filename) {
+  return (!this.include || micromatch.any(filename, this.include, {dotfiles: true})) && !micromatch.any(filename, this.exclude, {dotfiles: true})
 }
 
 TestExclude.prototype.pkgConf = function (key, path) {


### PR DESCRIPTION
To be able to filter not only the files being instrumented, but also in the reports it is required to filter the coveragemaps for the report.

E.G. Instrument and write to the cache directory using `nyc --silent ava` and later create specific report using e.g. `nyc report --include '**/bin/*.js` (ignoring all other files located in e.g. **/lib/**

In my specific this is required because my files are precompiled using rollup. This includes also files from external libraries in the resulting files. These files get tested (other the tests will fail due to import statements). However nyc will only exclude files actually present. It doesn't perform this action based on the  sourcemaps. Therefor I filter the report itself.